### PR TITLE
Use pkg-config instead of manual linked flags

### DIFF
--- a/alsa.go
+++ b/alsa.go
@@ -14,7 +14,7 @@ import (
 )
 
 /*
-#cgo LDFLAGS: -lasound
+#cgo pkg-config: alsa dl
 #include <alsa/asoundlib.h>
 #include <stdint.h>
 */


### PR DESCRIPTION
I had problems with include folders and that -ldl was missing. This should fix both problems. I can now use goalsa when cross compiling using xgo:

xgo -deps=http://alsa.mirror.fr/lib/alsa-lib-1.0.9.tar.bz2 -targets=linux/arm .

